### PR TITLE
Added a new meta tag "User-scale=No"

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <head>
 
     <meta charset="utf-8">
+	  <meta name="viewport" content="width=device-width, user-scalable=no">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="FYP Webpage">
     <meta name="author" content="James Qiu">


### PR DESCRIPTION
This means that the URL in question contains a viewport tag with the attribute user-scalable set to '0' or 'no', which prevents the user from zooming in or zooming out. Basically now the user wont be able to zoom into the webpage thus maitnting the responsiveness of the website.